### PR TITLE
Fix for drutiny issue #275 - depends expression always failing.

### DIFF
--- a/src/Policy/Dependency.php
+++ b/src/Policy/Dependency.php
@@ -123,7 +123,7 @@ class Dependency
     {
         try {
           $return = $audit->evaluate($this->expression, $this->syntax);
-          if ($return === 1) {
+          if ($return == 1) {
             return true;
           }
         } catch (\Exception $e) {


### PR DESCRIPTION
Change IF comparison from strict to loose